### PR TITLE
Fix an error C2666 in ccHObject.h. (#842)

### DIFF
--- a/libs/qCC_db/ccHObject.h
+++ b/libs/qCC_db/ccHObject.h
@@ -63,7 +63,7 @@ public: //base members access
 	inline CC_CLASS_ENUM getClassID() const override { return CC_TYPES::HIERARCHY_OBJECT; }
 
 	//! Returns whether the instance is a group
-	inline bool isGroup() const { return getClassID() == CC_TYPES::HIERARCHY_OBJECT; }
+	inline bool isGroup() const { return getClassID() == static_cast<CC_CLASS_ENUM>(CC_TYPES::HIERARCHY_OBJECT); }
 
 	//! Returns parent object
 	/** \return parent object (nullptr if no parent)


### PR DESCRIPTION
* Fix a error C2666 in ccHObject.h

* Use static_cast instead of C-style cast for error C2666 in ccHObject.h.