### PR TITLE
- CloudCompare can now load ASCII files with mixed whitespaces (space…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@ v2.11 (Anoia) - (in development)
 	- improved/fixed management of classification and classification flags
 	- LAS offset (chosen at saving time) should be a little bit smarter (CC will try to keep the previous one,
 		or use the bounding-box min corner ONLY if the coordinates are too large)
+  - ASCII:
+	- CloudCompare can now load ASCII files with mixed whitespaces (spaces / tabs)
+	- the ASCII load dialog option has now an option to load numerical values with a comma as digit separator
+		('use comma as decimal character' checkbox)
 
 - Changes
   - Command line tool:

--- a/libs/qCC_io/AsciiFilter.cpp
+++ b/libs/qCC_io/AsciiFilter.cpp
@@ -216,7 +216,7 @@ CC_FILE_ERROR AsciiFilter::saveToFile(ccHObject* entity, const QString& filename
 	//output precision
 	const int s_coordPrecision = saveDialog->coordsPrecision();
 	const int s_sfPrecision = saveDialog->sfPrecision(); 
-	const int s_nPrecision = 2+sizeof(PointCoordinateType);
+	const int s_nPrecision = 2 + sizeof(PointCoordinateType);
 
 	//other parameters
 	bool saveColumnsHeader = saveDialog->saveColumnsNamesHeader();
@@ -433,6 +433,7 @@ CC_FILE_ERROR AsciiFilter::loadFile(const QString& filename,
 
 	AsciiOpenDlg::Sequence openSequence = openDialog->getOpenSequence();
 	char separator = static_cast<char>(openDialog->getSeparator());
+	bool commaAsDecimal = openDialog->useCommaAsDecimal();
 	unsigned maxCloudSize = openDialog->getMaxCloudSize();
 	unsigned skipLineCount = openDialog->getSkippedLinesCount();
 	bool showLabelsIn2D = openDialog->showLabelsIn2D();
@@ -446,6 +447,7 @@ CC_FILE_ERROR AsciiFilter::loadFile(const QString& filename,
 											container,
 											openSequence,
 											separator,
+											commaAsDecimal,
 											approximateNumberOfLines,
 											fileSize,
 											maxCloudSize,
@@ -525,7 +527,6 @@ void clearStructure(cloudAttributesDescriptor &cloudDesc)
 cloudAttributesDescriptor prepareCloud(	const AsciiOpenDlg::Sequence &openSequence,
 										unsigned numberOfPoints,
 										int& maxIndex,
-										char separator,
 										unsigned step = 1)
 {
 	ccPointCloud* cloud = new ccPointCloud();
@@ -609,7 +610,7 @@ cloudAttributesDescriptor prepareCloud(	const AsciiOpenDlg::Sequence &openSequen
 				}
 				else
 				{
-					sfName.replace('_',separator);
+					sfName.replace('_', ' ');
 				}
 
 				ccScalarField* sf = new ccScalarField(qPrintable(sfName));
@@ -718,6 +719,7 @@ CC_FILE_ERROR AsciiFilter::loadCloudFromFormatedAsciiFile(	const QString& filena
 															ccHObject& container,
 															const AsciiOpenDlg::Sequence& openSequence,
 															char separator,
+															bool commaAsDecimal,
 															unsigned approximateNumberOfLines,
 															qint64 fileSize,
 															unsigned maxCloudSize,
@@ -733,7 +735,7 @@ CC_FILE_ERROR AsciiFilter::loadCloudFromFormatedAsciiFile(	const QString& filena
 
 	//we initialize the loading accelerator structure and point cloud
 	int maxPartIndex = -1;
-	cloudAttributesDescriptor cloudDesc = prepareCloud(openSequence, cloudChunkSize, maxPartIndex, separator, chunkRank);
+	cloudAttributesDescriptor cloudDesc = prepareCloud(openSequence, cloudChunkSize, maxPartIndex, chunkRank);
 
 	if (!cloudDesc.cloud)
 	{
@@ -788,6 +790,8 @@ CC_FILE_ERROR AsciiFilter::loadCloudFromFormatedAsciiFile(	const QString& filena
 	unsigned pointsRead = 0;
 
 	CC_FILE_ERROR result = CC_FERR_NO_ERROR;
+
+	QLocale locale(commaAsDecimal ? QLocale::French : QLocale::English);
 
 	//main process
 	unsigned nextLimit = /*cloudChunkPos+*/cloudChunkSize;
@@ -861,7 +865,7 @@ CC_FILE_ERROR AsciiFilter::loadCloudFromFormatedAsciiFile(	const QString& filena
 				//and create new one
 				cloudChunkPos = pointsRead;
 				cloudChunkSize = std::min(maxCloudSize, approximateNumberOfLines - cloudChunkPos);
-				cloudDesc = prepareCloud(openSequence, cloudChunkSize, maxPartIndex, separator, ++chunkRank);
+				cloudDesc = prepareCloud(openSequence, cloudChunkSize, maxPartIndex, ++chunkRank);
 				if (!cloudDesc.cloud)
 				{
 					ccLog::Error("Not enough memory! Process stopped ...");
@@ -884,7 +888,7 @@ CC_FILE_ERROR AsciiFilter::loadCloudFromFormatedAsciiFile(	const QString& filena
 		}
 
 		//we split current line
-		QStringList parts = currentLine.split(separator, QString::SkipEmptyParts);
+		QStringList parts = currentLine.simplified().split(separator, QString::SkipEmptyParts);
 
 		int nParts = parts.size();
 		if (nParts > maxPartIndex) //fake loop for easy break
@@ -896,7 +900,7 @@ CC_FILE_ERROR AsciiFilter::loadCloudFromFormatedAsciiFile(	const QString& filena
 				bool ok = true;
 				if (cloudDesc.xCoordIndex >= 0)
 				{
-					P.x = parts[cloudDesc.xCoordIndex].toDouble(&ok);
+					P.x = locale.toDouble(parts[cloudDesc.xCoordIndex], &ok);
 					if (!ok)
 					{
 						break;
@@ -904,7 +908,7 @@ CC_FILE_ERROR AsciiFilter::loadCloudFromFormatedAsciiFile(	const QString& filena
 				}
 				if (cloudDesc.yCoordIndex >= 0)
 				{
-					P.y = parts[cloudDesc.yCoordIndex].toDouble(&ok);
+					P.y = locale.toDouble(parts[cloudDesc.yCoordIndex], &ok);
 					if (!ok)
 					{
 						break;
@@ -912,7 +916,7 @@ CC_FILE_ERROR AsciiFilter::loadCloudFromFormatedAsciiFile(	const QString& filena
 				}
 				if (cloudDesc.zCoordIndex >= 0)
 				{
-					P.z = parts[cloudDesc.zCoordIndex].toDouble(&ok);
+					P.z = locale.toDouble(parts[cloudDesc.zCoordIndex], &ok);
 					if (!ok)
 					{
 						break;
@@ -948,11 +952,11 @@ CC_FILE_ERROR AsciiFilter::loadCloudFromFormatedAsciiFile(	const QString& filena
 			if (cloudDesc.hasNorms)
 			{
 				if (cloudDesc.xNormIndex >= 0)
-					N.x = static_cast<PointCoordinateType>(parts[cloudDesc.xNormIndex].toDouble());
+					N.x = static_cast<PointCoordinateType>(locale.toDouble(parts[cloudDesc.xNormIndex]));
 				if (cloudDesc.yNormIndex >= 0)
-					N.y = static_cast<PointCoordinateType>(parts[cloudDesc.yNormIndex].toDouble());
+					N.y = static_cast<PointCoordinateType>(locale.toDouble(parts[cloudDesc.yNormIndex]));
 				if (cloudDesc.zNormIndex >= 0)
-					N.z = static_cast<PointCoordinateType>(parts[cloudDesc.zNormIndex].toDouble());
+					N.z = static_cast<PointCoordinateType>(locale.toDouble(parts[cloudDesc.zNormIndex]));
 				cloudDesc.cloud->addNorm(N);
 			}
 
@@ -969,7 +973,7 @@ CC_FILE_ERROR AsciiFilter::loadCloudFromFormatedAsciiFile(	const QString& filena
 				}
 				else if (cloudDesc.fRgbaIndex >= 0)
 				{
-					const float rgbf = parts[cloudDesc.fRgbaIndex].toFloat();
+					const float rgbf = locale.toFloat(parts[cloudDesc.fRgbaIndex]);
 					const uint32_t rgb = *(reinterpret_cast<const uint32_t *>(&rgbf));
 					col.r = ((rgb >> 16) & 0x0000ff);
 					col.g = ((rgb >>  8) & 0x0000ff);
@@ -980,17 +984,17 @@ CC_FILE_ERROR AsciiFilter::loadCloudFromFormatedAsciiFile(	const QString& filena
 					if (cloudDesc.redIndex >= 0)
 					{
 						float multiplier = cloudDesc.hasFloatRGBColors[0] ? static_cast<float>(ccColor::MAX) : 1.0f;
-						col.r = static_cast<ColorCompType>(parts[cloudDesc.redIndex].toFloat() * multiplier);
+						col.r = static_cast<ColorCompType>(locale.toFloat(parts[cloudDesc.redIndex]) * multiplier);
 					}
 					if (cloudDesc.greenIndex >= 0)
 					{
 						float multiplier = cloudDesc.hasFloatRGBColors[1] ? static_cast<float>(ccColor::MAX) : 1.0f;
-						col.g = static_cast<ColorCompType>(parts[cloudDesc.greenIndex].toFloat() * multiplier);
+						col.g = static_cast<ColorCompType>(locale.toFloat(parts[cloudDesc.greenIndex]) * multiplier);
 					}
 					if (cloudDesc.blueIndex >= 0)
 					{
 						float multiplier = cloudDesc.hasFloatRGBColors[2] ? static_cast<float>(ccColor::MAX) : 1.0f;
-						col.b = static_cast<ColorCompType>(parts[cloudDesc.blueIndex].toFloat() * multiplier);
+						col.b = static_cast<ColorCompType>(locale.toFloat(parts[cloudDesc.blueIndex]) * multiplier);
 					}
 				}
 				cloudDesc.cloud->addRGBColor(col);
@@ -1006,7 +1010,7 @@ CC_FILE_ERROR AsciiFilter::loadCloudFromFormatedAsciiFile(	const QString& filena
 			{
 				for (size_t j = 0; j < cloudDesc.scalarIndexes.size(); ++j)
 				{
-					D = static_cast<ScalarType>(parts[cloudDesc.scalarIndexes[j]].toDouble());
+					D = static_cast<ScalarType>(locale.toDouble(parts[cloudDesc.scalarIndexes[j]]));
 					cloudDesc.scalarFields[j]->emplace_back(D);
 				}
 			}

--- a/libs/qCC_io/AsciiFilter.h
+++ b/libs/qCC_io/AsciiFilter.h
@@ -44,6 +44,7 @@ public:
 													ccHObject& container,
 													const AsciiOpenDlg::Sequence& openSequence,
 													char separator,
+													bool commaAsDecimal,
 													unsigned approximateNumberOfLines,
 													qint64 fileSize,
 													unsigned maxCloudSize,

--- a/libs/qCC_io/AsciiOpenDlg.h
+++ b/libs/qCC_io/AsciiOpenDlg.h
@@ -154,6 +154,9 @@ public:
 	//! Returns user selected separator
 	unsigned char getSeparator() const { return m_separator.cell(); }
 
+	//! Returns whether comma should be used as decimal point
+	bool useCommaAsDecimal() const;
+
 	//! Returns roughly estimated average line size (in bytes)
 	double getAverageLineSize() const { return m_averageLineSize; }
 
@@ -187,6 +190,8 @@ public slots:
 	void updateTable();
 	//! Sets the number of lines to skip
 	void setSkippedLines(int linesCount);
+	//! Slot called when the 'comma as decimal' checkbox is toggled
+	void commaDecimalCheckBoxToggled(bool);
 
 protected slots:
 	bool apply();
@@ -199,6 +204,9 @@ protected:
 
 	//! Tries to guess the best separator automagically
 	void autoFindBestSeparator();
+
+	//! Sets the current separator
+	void setSeparator(QChar);
 
 	//associated UI
 	Ui_AsciiOpenDialog* m_ui;

--- a/libs/qCC_io/ui_templates/openAsciiFileDlg.ui
+++ b/libs/qCC_io/ui_templates/openAsciiFileDlg.ui
@@ -74,8 +74,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>984</width>
-        <height>430</height>
+        <width>990</width>
+        <height>486</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -152,28 +152,30 @@
      <item>
       <layout class="QHBoxLayout">
        <item>
-        <widget class="QToolButton" name="toolButtonShortcutESP">
-         <property name="text">
-          <string>ESP</string>
+        <widget class="QToolButton" name="toolButtonShortcutSpace">
+         <property name="toolTip">
+          <string>space</string>
          </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QToolButton" name="toolButtonShortcutTAB">
          <property name="text">
-          <string>TAB</string>
+          <string>whitespace </string>
          </property>
         </widget>
        </item>
        <item>
         <widget class="QToolButton" name="toolButtonShortcutComma">
+         <property name="toolTip">
+          <string>comma</string>
+         </property>
          <property name="text">
           <string notr="true">,</string>
          </property>
         </widget>
        </item>
        <item>
-        <widget class="QToolButton" name="toolButtonShortcutDotcomma">
+        <widget class="QToolButton" name="toolButtonShortcutSemicolon">
+         <property name="toolTip">
+          <string>semicolon</string>
+         </property>
          <property name="text">
           <string notr="true">;</string>
          </property>
@@ -191,6 +193,13 @@
           </size>
          </property>
         </spacer>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="commaDecimalCheckBox">
+         <property name="text">
+          <string>use comma as decimal character</string>
+         </property>
+        </widget>
        </item>
        <item>
         <widget class="QCheckBox" name="show2DLabelsCheckBox">


### PR DESCRIPTION
…s / tabs)

- The ASCII load dialog option has now an option to load numerical values with a comma as digit separator