### PR TITLE
Unroll tool updated:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,10 @@ v2.11 (Anoia) - (in development)
 	- CloudCompare can now load ASCII files with mixed whitespaces (spaces / tabs)
 	- the ASCII load dialog option has now an option to load numerical values with a comma as digit separator
 		('use comma as decimal character' checkbox)
+  - Unroll
+	- ability to set the start and stop angles for the cone unrolling options
+	- new unrolling mode: 'Straightened cone' (the previous one has been renamed 'Straightened cone (fixed radius)'). This new mode unrolls the cone as a cylinder but with a varying radius.
+	- the 'Straightened cone' options are now using the real curvilinear abscissa (0 = cone apex)
 
 - Changes
   - Command line tool:
@@ -66,6 +70,7 @@ v2.11 (Anoia) - (in development)
 - Bug fix:
 	- LAS classification flags were not always properly extracted/saved by the standard LAS filter (depending on the point format)
 	- Trace Polyline tool: when changing the OpenGL camera position while tracing a polyline AND using oversampling, strange spikes could appear
+	- the Unroll dialog was not enabling all the apex coordinate fields after switching from Cylinder to Cone mode
 
 v2.10.3 (Zephyrus) - 13/06/2019
 ----------------------

--- a/libs/qCC_db/ccPointCloud.cpp
+++ b/libs/qCC_db/ccPointCloud.cpp
@@ -3487,99 +3487,155 @@ bool ccPointCloud::interpolateColorsFrom(	ccGenericPointCloud* otherCloud,
 											CCLib::GenericProgressCallback* progressCb/*=nullptr*/,
 											unsigned char octreeLevel/*=0*/)
 {
-if (!otherCloud || otherCloud->size() == 0)
-{
-	ccLog::Warning("[ccPointCloud::interpolateColorsFrom] Invalid/empty input cloud!");
-	return false;
-}
-
-//check that both bounding boxes intersect!
-ccBBox box = getOwnBB();
-ccBBox otherBox = otherCloud->getOwnBB();
-
-CCVector3 dimSum = box.getDiagVec() + otherBox.getDiagVec();
-CCVector3 dist = box.getCenter() - otherBox.getCenter();
-if (fabs(dist.x) > dimSum.x / 2
-	|| fabs(dist.y) > dimSum.y / 2
-	|| fabs(dist.z) > dimSum.z / 2)
-{
-	ccLog::Warning("[ccPointCloud::interpolateColorsFrom] Clouds are too far from each other! Can't proceed.");
-	return false;
-}
-
-//compute the closest-point set of 'this cloud' relatively to 'input cloud'
-//(to get a mapping between the resulting vertices and the input points)
-QSharedPointer<CCLib::ReferenceCloud> CPSet = computeCPSet(*otherCloud, progressCb, octreeLevel);
-if (!CPSet)
-{
-	return false;
-}
-
-if (!resizeTheRGBTable(false))
-{
-	ccLog::Warning("[ccPointCloud::interpolateColorsFrom] Not enough memory!");
-	return false;
-}
-
-//import colors
-unsigned CPSetSize = CPSet->size();
-assert(CPSetSize == size());
-for (unsigned i = 0; i < CPSetSize; ++i)
-{
-	unsigned index = CPSet->getPointGlobalIndex(i);
-	setPointColor(i, otherCloud->getPointColor(index));
-}
-
-//We must update the VBOs
-colorsHaveChanged();
-
-return true;
-}
-
-ccPointCloud* ccPointCloud::unrollOnCylinder(PointCoordinateType radius,
-	unsigned char coneAxisDim,
-	CCVector3* center,
-	bool exportDeviationSF/*=false*/,
-	double startAngle_deg/*=0.0*/,
-	double stopAngle_deg/*=360.0*/,
-	CCLib::GenericProgressCallback* progressCb/*=nullptr*/) const
-{
-
-	if (startAngle_deg >= stopAngle_deg)
+	if (!otherCloud || otherCloud->size() == 0)
 	{
+		ccLog::Warning("[ccPointCloud::interpolateColorsFrom] Invalid/empty input cloud!");
+		return false;
+	}
+
+	//check that both bounding boxes intersect!
+	ccBBox box = getOwnBB();
+	ccBBox otherBox = otherCloud->getOwnBB();
+
+	CCVector3 dimSum = box.getDiagVec() + otherBox.getDiagVec();
+	CCVector3 dist = box.getCenter() - otherBox.getCenter();
+	if (	fabs(dist.x) > dimSum.x / 2
+		||	fabs(dist.y) > dimSum.y / 2
+		||	fabs(dist.z) > dimSum.z / 2)
+	{
+		ccLog::Warning("[ccPointCloud::interpolateColorsFrom] Clouds are too far from each other! Can't proceed.");
+		return false;
+	}
+
+	//compute the closest-point set of 'this cloud' relatively to 'input cloud'
+	//(to get a mapping between the resulting vertices and the input points)
+	QSharedPointer<CCLib::ReferenceCloud> CPSet = computeCPSet(*otherCloud, progressCb, octreeLevel);
+	if (!CPSet)
+	{
+		return false;
+	}
+
+	if (!resizeTheRGBTable(false))
+	{
+		ccLog::Warning("[ccPointCloud::interpolateColorsFrom] Not enough memory!");
+		return false;
+	}
+
+	//import colors
+	unsigned CPSetSize = CPSet->size();
+	assert(CPSetSize == size());
+	for (unsigned i = 0; i < CPSetSize; ++i)
+	{
+		unsigned index = CPSet->getPointGlobalIndex(i);
+		setPointColor(i, otherCloud->getPointColor(index));
+	}
+
+	//We must update the VBOs
+	colorsHaveChanged();
+
+	return true;
+}
+
+static void ProjectOnCylinder(	const CCVector3& AP,
+								const Tuple3ub& dim,
+								PointCoordinateType radius,
+								PointCoordinateType& delta,
+								PointCoordinateType& phi_rad)
+{
+	//2D distance to the center (XY plane)
+	PointCoordinateType APnorm_XY = sqrt(AP.u[dim.x] * AP.u[dim.x] + AP.u[dim.y] * AP.u[dim.y]);
+	//longitude (0 = +X = east)
+	phi_rad = atan2(AP.u[dim.y], AP.u[dim.x]);
+	//deviation
+	delta = APnorm_XY - radius;
+}
+
+static void ProjectOnCone(	const CCVector3& AP,
+							PointCoordinateType alpha_rad,
+							const Tuple3ub& dim,
+							PointCoordinateType& s,
+							PointCoordinateType& delta,
+							PointCoordinateType& phi_rad)
+{
+	//3D distance to the apex
+	PointCoordinateType normAP = AP.norm();
+	//2D distance to the apex (XY plane)
+	PointCoordinateType normAP_XY = sqrt(AP.u[dim.x] * AP.u[dim.x] + AP.u[dim.y] * AP.u[dim.y]);
+
+	//angle between +Z and AP
+	PointCoordinateType beta_rad = atan2(normAP_XY, -AP.u[dim.z]);
+	//angular deviation
+	PointCoordinateType gamma_rad = beta_rad - alpha_rad; //if gamma_rad > 0, the point is outside the cone
+
+	//projection on the cone
+	{
+		//longitude (0 = +X = east)
+		phi_rad = atan2(AP.u[dim.y], AP.u[dim.x]);
+		//curvilinear distance from the Apex
+		s = normAP * cos(gamma_rad);
+		//(normal) deviation
+		delta = normAP * sin(gamma_rad);
+	}
+}
+
+ccPointCloud* ccPointCloud::unroll(	UnrollMode mode,
+									UnrollBaseParams* params,
+									bool exportDeviationSF/*=false*/,
+									double startAngle_deg/*=0.0*/,
+									double stopAngle_deg/*=360.0*/,
+									CCLib::GenericProgressCallback* progressCb/*=nullptr*/) const
+{
+	if (	!params
+		||	params->axisDim > 2
+		||	startAngle_deg >= stopAngle_deg)
+	{
+		//invalid input parameters
 		assert(false);
 		return nullptr;
 	}
-	if (coneAxisDim > 2)
+
+	QString modeStr;
+	UnrollCylinderParams* cylParams = nullptr;
+	UnrollConeParams* coneParams = nullptr;
+
+	switch (mode)
 	{
+	case CYLINDER:
+		modeStr = "Cylinder";
+		cylParams = static_cast<UnrollCylinderParams*>(params);
+		break;
+	case CONE:
+		modeStr = "Cone";
+		coneParams = static_cast<UnrollConeParams*>(params);
+		break;
+	case STRAIGHTENED_CONE:
+	case STRAIGHTENED_CONE2:
+		modeStr = "Straightened cone";
+		coneParams = static_cast<UnrollConeParams*>(params);
+		break;
+	default:
 		assert(false);
 		return nullptr;
 	}
 
 	Tuple3ub dim;
-	dim.z = coneAxisDim;
+	dim.z = params->axisDim;
 	dim.x = (dim.z < 2 ? dim.z + 1 : 0);
 	dim.y = (dim.x < 2 ? dim.x + 1 : 0);
 
 	unsigned numberOfPoints = size();
-
 	CCLib::NormalizedProgress nprogress(progressCb, numberOfPoints);
 	if (progressCb)
 	{
 		if (progressCb->textCanBeEdited())
 		{
-			progressCb->setMethodTitle("Unroll (cylinder)");
+			progressCb->setMethodTitle(qPrintable(QString("Unroll (%1)").arg(modeStr)));
 			progressCb->setInfo(qPrintable(QString("Number of points = %1").arg(numberOfPoints)));
 		}
 		progressCb->update(0);
 		progressCb->start();
 	}
 
-	//ccPointCloud* clone = const_cast<ccPointCloud*>(this)->cloneThis(0, true);
-	//if (!clone)
-	//{
-	//	return 0;
-	//}
 	CCLib::ReferenceCloud duplicatedPoints(const_cast<ccPointCloud*>(this));
 	std::vector<CCVector3> unrolledPoints;
 	{
@@ -3602,10 +3658,19 @@ ccPointCloud* ccPointCloud::unrollOnCylinder(PointCoordinateType radius,
 		}
 	}
 
-	
-	std::vector<CCVector3> unrolledNormals;
 	std::vector<ScalarType> deviationValues;
+	if (exportDeviationSF)
+	try
+	{
+		deviationValues.resize(size());
+	}
+	catch (const std::bad_alloc&)
+	{
+		//not enough memory
+		return nullptr;
+	}
 
+	std::vector<CCVector3> unrolledNormals;
 	bool withNormals = hasNormals();
 	if (withNormals)
 	{
@@ -3614,7 +3679,6 @@ ccPointCloud* ccPointCloud::unrollOnCylinder(PointCoordinateType radius,
 		try
 		{
 			unrolledNormals.resize(size());
-			deviationValues.resize(size());
 		}
 		catch (const std::bad_alloc&)
 		{
@@ -3623,67 +3687,164 @@ ccPointCloud* ccPointCloud::unrollOnCylinder(PointCoordinateType radius,
 		}
 	}
 	
-	//compute cylinder center (if none was provided)
-	CCVector3 C;
-	if (!center)
-	{
-		C = const_cast<ccPointCloud*>(this)->getOwnBB().getCenter();
-		center = &C;
-	}
-
 	double startAngle_rad = startAngle_deg * CC_DEG_TO_RAD;
 	double stopAngle_rad = stopAngle_deg * CC_DEG_TO_RAD;
+
+	PointCoordinateType alpha_rad = 0, sin_alpha = 0;
+	if (mode != CYLINDER)
+	{
+		alpha_rad = coneParams->coneAngle_deg * CC_DEG_TO_RAD;
+		sin_alpha = static_cast<PointCoordinateType>(sin(alpha_rad));
+	}
 
 	for (unsigned i = 0; i < numberOfPoints; i++)
 	{
 		const CCVector3* Pin = getPoint(i);
-		
-		CCVector3 CP = *Pin - *center;
-
-		PointCoordinateType u = sqrt(CP.u[dim.x] * CP.u[dim.x] + CP.u[dim.y] * CP.u[dim.y]);
-		double longitude_rad = atan2(static_cast<double>(CP.u[dim.x]), static_cast<double>(CP.u[dim.y]));
 
 		//we project the point
-		CCVector3 Pout;
-		//Pout.u[dim.x] = longitude_rad * radius;
-		Pout.u[dim.y] = u - radius;
-		Pout.u[dim.z] = Pin->u[dim.z];
+		CCVector3 AP, Pout;
+		PointCoordinateType longitude_rad = 0; //longitude (rad)
+		PointCoordinateType delta = 0; //distance to the cone/cylinder surface
+		PointCoordinateType coneAbscissa = 0;
 
+		switch (mode)
+		{
+		case CYLINDER:
+		{
+			AP = *Pin - cylParams->center;
+			ProjectOnCylinder(AP, dim, params->radius, delta, longitude_rad);
+
+			//we project the point
+			//Pout.u[dim.x] = longitude_rad * radius;
+			Pout.u[dim.y] = -delta;
+			Pout.u[dim.z] = Pin->u[dim.z];
+		}
+		break;
+
+		case STRAIGHTENED_CONE:
+		{
+			AP = *Pin - coneParams->apex;
+			ProjectOnCone(AP, alpha_rad, dim, coneAbscissa, delta, longitude_rad);
+			//we simply develop the cone as a cylinder
+			//Pout.u[dim.x] = phi_rad * params->radius;
+			Pout.u[dim.y] = -delta;
+			//Pout.u[dim.z] = Pin->u[dim.z];
+			Pout.u[dim.z] = coneParams->apex.u[dim.z] - coneAbscissa;
+		}
+		break;
+
+		case STRAIGHTENED_CONE2:
+		{
+			AP = *Pin - coneParams->apex;
+			ProjectOnCone(AP, alpha_rad, dim, coneAbscissa, delta, longitude_rad);
+			//we simply develop the cone as a cylinder
+			//Pout.u[dim.x] = phi_rad * coneAbscissa * sin_alpha;
+			Pout.u[dim.y] = -delta;
+			//Pout.u[dim.z] = Pin->u[dim.z];
+			Pout.u[dim.z] = coneParams->apex.u[dim.z] - coneAbscissa;
+		}
+		break;
+
+		case CONE:
+		{
+			AP = *Pin - coneParams->apex;
+			ProjectOnCone(AP, alpha_rad, dim, coneAbscissa, delta, longitude_rad);
+			//unrolling
+			PointCoordinateType theta_rad = longitude_rad * sin_alpha; //sin_alpha is a bit arbitrary here. The aim is mostly to reduce the angular range
+			//project the point
+			Pout.u[dim.y] = -coneAbscissa * cos(theta_rad);
+			Pout.u[dim.x] =  coneAbscissa * sin(theta_rad);
+			Pout.u[dim.z] = delta;
+		}
+		break;
+
+		default:
+			assert(false);
+		}
+		
 		// first unroll its normal if necessary
 		if (withNormals)
 		{
 			const CCVector3& N = getPointNormal(i);
-
-			PointCoordinateType px = CP.u[dim.x] + N.u[dim.x];
-			PointCoordinateType py = CP.u[dim.y] + N.u[dim.y];
-			PointCoordinateType nu = sqrt(px*px + py*py);
-			double nLongitude_rad = atan2(static_cast<double>(px), static_cast<double>(py));
-
+			CCVector3 AP2 = AP + N;
 			CCVector3 N2;
-			N2.u[dim.x] = static_cast<PointCoordinateType>((nLongitude_rad - longitude_rad) * radius);
-			N2.u[dim.y] = nu - u;
-			N2.u[dim.z] = N.u[dim.z];
+
+			switch (mode)
+			{
+			case CYLINDER:
+			{
+				PointCoordinateType delta2, longitude2_rad;
+				ProjectOnCylinder(AP2, dim, params->radius, delta2, longitude2_rad);
+
+				N2.u[dim.x] = static_cast<PointCoordinateType>((longitude2_rad - longitude_rad) * params->radius);
+				N2.u[dim.y] = -(delta2 - delta);
+				N2.u[dim.z] = N.u[dim.z];
+			}
+			break;
+
+			case STRAIGHTENED_CONE:
+			{
+				PointCoordinateType coneAbscissa2, delta2, longitude2_rad;
+				ProjectOnCone(AP2, alpha_rad, dim, coneAbscissa2, delta2, longitude2_rad);
+				//we simply develop the cone as a cylinder
+				N2.u[dim.x] = static_cast<PointCoordinateType>((longitude2_rad - longitude_rad) * params->radius);
+				N2.u[dim.y] = -(delta2 - delta);
+				N2.u[dim.z] = coneAbscissa - coneAbscissa2;
+			}
+			break;
+
+			case STRAIGHTENED_CONE2:
+			{
+				PointCoordinateType coneAbscissa2, delta2, longitude2_rad;
+				ProjectOnCone(AP2, alpha_rad, dim, coneAbscissa2, delta2, longitude2_rad);
+				//we simply develop the cone as a cylinder
+				N2.u[dim.x] = static_cast<PointCoordinateType>((longitude2_rad * coneAbscissa - longitude_rad * coneAbscissa2) * sin_alpha);
+				N2.u[dim.y] = -(delta2 - delta);
+				N2.u[dim.z] = coneAbscissa - coneAbscissa2;
+			}
+			break;
+
+			case CONE:
+			{
+				PointCoordinateType coneAbscissa2, delta2, longitude2_rad;
+				ProjectOnCone(AP2, alpha_rad, dim, coneAbscissa2, delta2, longitude2_rad);
+				//unrolling
+				PointCoordinateType theta2_rad = longitude2_rad * sin_alpha; //sin_alpha is a bit arbitrary here. The aim is mostly to reduce the angular range
+				//project the point
+				CCVector3 P2out;
+				P2out.u[dim.x] =  coneAbscissa2 * sin(theta2_rad);
+				P2out.u[dim.y] = -coneAbscissa2 * cos(theta2_rad);
+				P2out.u[dim.z] = delta2;
+				N2 = P2out - Pout;
+			}
+			break;
+
+			default:
+				assert(false);
+				break;
+			}
+
 			N2.normalize();
 			unrolledNormals[i] = N2;
-			//clone->setPointNormal(i, N2);
 		}
 
 		//then compute the deviation (if necessary)
 		if (exportDeviationSF)
 		{
-			deviationValues[i] = static_cast<ScalarType>(Pout.u[dim.y]);
+			deviationValues[i] = static_cast<ScalarType>(delta);
 		}
 
 		//then repeat the unrolling process for the coordinates
-		//1) poition the 'point' at the beginning of the angular range
-		while (longitude_rad >= startAngle_rad)
+		//1) position the 'point' at the beginning of the angular range
+		double dLongitude_rad = longitude_rad;
+		while (dLongitude_rad >= startAngle_rad)
 		{
-			longitude_rad -= 2 * M_PI;
+			dLongitude_rad -= 2 * M_PI;
 		}
-		longitude_rad += 2 * M_PI;
+		dLongitude_rad += 2 * M_PI;
 
 		//2) repeat the unrolling process
-		for (; longitude_rad < stopAngle_rad; longitude_rad += 2 * M_PI)
+		for (; dLongitude_rad < stopAngle_rad; dLongitude_rad += 2 * M_PI)
 		{
 			//do we need to reserve more memory?
 			if (duplicatedPoints.size() == duplicatedPoints.capacity())
@@ -3707,7 +3868,26 @@ ccPointCloud* ccPointCloud::unrollOnCylinder(PointCoordinateType radius,
 			}
 
 			//add the point
-			Pout.u[dim.x] = longitude_rad * radius;
+			switch (mode)
+			{
+			case CYLINDER:
+			case STRAIGHTENED_CONE:
+				Pout.u[dim.x] = dLongitude_rad * params->radius;
+				break;
+			case STRAIGHTENED_CONE2:
+				Pout.u[dim.x] = dLongitude_rad * coneAbscissa * sin_alpha;
+				break;
+
+			case CONE:
+				Pout.u[dim.x] =  coneAbscissa * sin(dLongitude_rad);
+				Pout.u[dim.y] = -coneAbscissa * cos(dLongitude_rad);
+				//Pout = coneParams->apex + Pout; //nope, this projection is arbitrary and should be centered on (0, 0, 0)
+				break;
+
+			default:
+				assert(false);
+			}
+
 			unrolledPoints.push_back(Pout);
 			duplicatedPoints.addPointIndex(i);
 		}
@@ -3778,192 +3958,6 @@ ccPointCloud* ccPointCloud::unrollOnCylinder(PointCoordinateType radius,
 	return clone;
 }
 
-static void ProjectOnCone(	const CCVector3& P,
-							const CCVector3& coneApex,
-							PointCoordinateType alpha_rad,
-							const Tuple3ub& dim,
-							PointCoordinateType& s,
-							PointCoordinateType& delta,
-							PointCoordinateType& phi_rad)
-{
-	CCVector3 AP = P - coneApex;
-	//3D distance to the apex
-	PointCoordinateType normAP = AP.norm();
-	//2D distance to the apex (XY plane)
-	PointCoordinateType u = sqrt(AP.u[dim.x] * AP.u[dim.x] + AP.u[dim.y] * AP.u[dim.y]);
-
-	//angle between +Z and AP
-	PointCoordinateType beta_rad = atan2(u, -AP.u[dim.z]);
-	//angular deviation
-	PointCoordinateType gamma_rad = beta_rad - alpha_rad; //if gamma_rad > 0, the point is outside the cone
-
-	//projection on the cone
-	{
-		//longitude (0 = +X = east)
-		phi_rad = atan2(AP.u[dim.y], AP.u[dim.x]);
-		//curvilinear distance from the Apex
-		s = normAP * cos(gamma_rad);
-		//(normal) deviation
-		delta = normAP * sin(gamma_rad);
-	}
-}
-
-ccPointCloud* ccPointCloud::unrollOnCone(	double coneAngle_deg,
-											const CCVector3& coneApex,
-											unsigned char coneAxisDim,
-											bool developStraightenedCone,
-											PointCoordinateType baseRadius,
-											bool exportDeviationSF/*=false*/,
-											CCLib::GenericProgressCallback* progressCb/*=nullptr*/) const
-{
-	if (coneAxisDim > 2)
-	{
-		assert(false);
-		return nullptr;
-	}
-
-	Tuple3ub dim;
-	dim.z = coneAxisDim;
-	dim.x = (dim.z < 2 ? dim.z + 1 : 0);
-	dim.y = (dim.x < 2 ? dim.x + 1 : 0);
-
-	unsigned numberOfPoints = size();
-
-	CCLib::NormalizedProgress nprogress(progressCb, numberOfPoints);
-	if (progressCb)
-	{
-		if (progressCb->textCanBeEdited())
-		{
-			progressCb->setMethodTitle("Unroll (cone)");
-			progressCb->setInfo(qPrintable(QString("Number of points = %1").arg(numberOfPoints)));
-		}
-		progressCb->update(0);
-		progressCb->start();
-	}
-
-	ccPointCloud* clone = const_cast<ccPointCloud*>(this)->cloneThis(nullptr, true);
-	if (!clone)
-	{
-		return nullptr;
-	}
-
-	CCLib::ScalarField* deviationSF = nullptr;
-	if (exportDeviationSF)
-	{
-		int sfIdx = clone->getScalarFieldIndexByName(s_deviationSFName);
-		if (sfIdx < 0)
-		{
-			sfIdx = clone->addScalarField(s_deviationSFName);
-			if (sfIdx < 0)
-			{
-				ccLog::Warning("[unrollOnCone] Not enough memory to init the deviation scalar field");
-			}
-		}
-		if (sfIdx >= 0)
-		{
-			deviationSF = clone->getScalarField(sfIdx);
-		}
-		clone->setCurrentDisplayedScalarField(sfIdx);
-		clone->showSF(true);
-	}
-	
-	PointCoordinateType alpha_rad = coneAngle_deg * CC_DEG_TO_RAD;
-	PointCoordinateType sin_alpha = static_cast<PointCoordinateType>( sin(alpha_rad) );
-
-	for (unsigned i = 0; i < numberOfPoints; i++)
-	{
-		const CCVector3* Pin = getPoint(i);
-
-		PointCoordinateType s, delta, phi_rad;
-		ProjectOnCone(*Pin, coneApex, alpha_rad, dim, s, delta, phi_rad);
-
-		if (deviationSF)
-		{
-			deviationSF->setValue(i, delta);
-		}
-
-		CCVector3 Pout;
-		if (developStraightenedCone)
-		{
-			//we simply develop the cone as a cylinder
-			Pout.u[dim.x] = (baseRadius + delta) * cos(phi_rad);
-			Pout.u[dim.y] = (baseRadius + delta) * sin(phi_rad);
-			Pout.u[dim.z] = coneApex.u[dim.z] - s;
-		}
-		else
-		{
-			//unrolling
-			PointCoordinateType theta_rad = phi_rad * sin_alpha;
-
-			//project the point
-			Pout.u[dim.y] = -s * cos(theta_rad);
-			Pout.u[dim.x] =  s * sin(theta_rad);
-			Pout.u[dim.z] = delta;
-		}
-
-		//replace the point in the destination cloud
-		*clone->point(i) = Pout;
-
-		//and its normal if necessary
-		if (clone->hasNormals())
-		{
-			const CCVector3& N = clone->getPointNormal(i);
-
-			PointCoordinateType s2, delta2, phi2_rad;
-			ProjectOnCone(*Pin + N, coneApex, alpha_rad, dim, s2, delta2, phi2_rad);
-
-			CCVector3 P2out;
-			if (developStraightenedCone)
-			{
-				//we simply develop the cone as a cylinder
-				P2out.u[dim.x] = (baseRadius + delta2) * cos(phi2_rad);
-				P2out.u[dim.y] = (baseRadius + delta2) * sin(phi2_rad);
-				P2out.u[dim.z] = coneApex.u[dim.z] - s2;
-			}
-			else
-			{
-				//unrolling
-				PointCoordinateType theta2_rad = phi2_rad * sin_alpha;
-
-				//project the point
-				P2out.u[dim.y] = -s2 * cos(theta2_rad);
-				P2out.u[dim.x] =  s2 * sin(theta2_rad);
-				P2out.u[dim.z] = delta2;
-			}
-
-			CCVector3 N2 = P2out - Pout;
-			N2.normalize();
-
-			clone->setPointNormal(i, N2);
-		}
-
-		//process canceled by user?
-		if (progressCb && !nprogress.oneStep())
-		{
-			delete clone;
-			clone = nullptr;
-			break;
-		}
-	}
-
-	if (progressCb)
-	{
-		progressCb->stop();
-	}
-
-	if (clone)
-	{
-		if (deviationSF)
-		{
-			deviationSF->computeMinAndMax();
-		}
-
-		clone->setName(getName() + ".unrolled");
-		clone->refreshBB(); //calls notifyGeometryUpdate + releaseVBOs
-	}
-
-	return clone;
-}
 
 //void ccPointCloud::unrollOnCone(PointCoordinateType baseRadius,
 //	double alpha_deg,

--- a/libs/qCC_db/ccPointCloud.h
+++ b/libs/qCC_db/ccPointCloud.h
@@ -633,41 +633,40 @@ public: //other methods
 	**/
 	void hidePointsByScalarValue(ScalarType minVal, ScalarType maxVal);
 
-	//! Unrolls the cloud and its normals on a cylinder
+	enum UnrollMode { CYLINDER = 0, CONE = 1, STRAIGHTENED_CONE = 2, STRAIGHTENED_CONE2 = 3 };
+
+	struct UnrollBaseParams
+	{
+		PointCoordinateType radius;	//!< unrolling cylinder radius (or cone base radius)
+		unsigned char axisDim;		//!< unrolling cylinder/cone axis (X=0, Y=1 or Z=2)
+	};
+	struct UnrollCylinderParams : public UnrollBaseParams
+	{
+		CCVector3 center;			//! A point belonging to the cylinder axis
+	};
+	struct UnrollConeParams : public UnrollBaseParams
+	{
+		CCVector3 apex;				//! Cone apex
+		double coneAngle_deg;		//! Cone aperture angle (in degrees)
+	};
+
+	//! Unrolls the cloud and its normals on a cylinder or a cone
 	/** This method is redundant with the "developCloudOnCylinder" method of CCLib,
 		apart that it can also handle the cloud normals.
-		\param radius unrolling cylinder radius
-		\param coneAxisDim dimension along which the cylinder axis is aligned (X=0, Y=1, Z=2)
-		\param center a point belonging to the cylinder axis (automatically computed if not specified)
+		\param mode unrolling mode
+		\param params unrolling parameters (must match the unrolling mode)
 		\param exportDeviationSF to export the deviation fro the ideal cone as a scalar field
+		\param startAngle_deg start angle (in degrees) - 0 corresponds to +X (east)
+		\param stopAngle_deg stop angle (in degrees)
 		\param progressCb for progress notification
 		\return the unrolled point cloud
 		**/
-	ccPointCloud* unrollOnCylinder(	PointCoordinateType radius,
-									unsigned char coneAxisDim,
-									CCVector3* center = nullptr,
-									bool exportDeviationSF = false,
-									double startAngle_deg = 0.0,
-									double stopAngle_deg = 360.0,
-									CCLib::GenericProgressCallback* progressCb = nullptr) const;
-
-	//! Unrolls the cloud (and its normals) on a cone
-	/** \param coneAngle_deg cone apex angle (between 0 and 180 degrees)
-		\param coneApex cone apex 3D position
-		\param coneAxisDim dimension along which the cone axis is aligned (X=0, Y=1, Z=2)
-		\param developStraightenedCone if true, this method will unroll a straightened version of the cone (as a cylinder)
-		\param baseRadius unrolling straightened cone base radius (necessary if developStraightenedCone is true)
-		\param exportDeviationSF to export the deviation fro the ideal cone as a scalar field
-		\param progressCb for progress notification
-		\return the unrolled point cloud
-	**/
-	ccPointCloud* unrollOnCone(	double coneAngle_deg,
-								const CCVector3& coneApex,
-								unsigned char coneAxisDim,
-								bool developStraightenedCone,
-								PointCoordinateType baseRadius,
-								bool exportDeviationSF = false,
-								CCLib::GenericProgressCallback* progressCb = nullptr) const;
+	ccPointCloud* unroll(	UnrollMode mode,
+							UnrollBaseParams* params,
+							bool exportDeviationSF = false,
+							double startAngle_deg = 0.0,
+							double stopAngle_deg = 360.0,
+							CCLib::GenericProgressCallback* progressCb = nullptr) const;
 
 	//! Adds associated SF color ramp info to current GL context
 	void addColorRampInfo(CC_DRAW_CONTEXT& context);

--- a/qCC/ccUnrollDlg.cpp
+++ b/qCC/ccUnrollDlg.cpp
@@ -36,9 +36,9 @@ ccUnrollDlg::ccUnrollDlg(QWidget* parent/*=0*/)
 	axisDimensionChanged(comboBoxAxisDimension->currentIndex());
 }
 
-ccUnrollDlg::Type ccUnrollDlg::getType() const
+ccPointCloud::UnrollMode ccUnrollDlg::getType() const
 {
-	return static_cast<Type>(comboBoxUnrollShapeType->currentIndex());
+	return static_cast<ccPointCloud::UnrollMode>(comboBoxUnrollShapeType->currentIndex());
 }
 
 int ccUnrollDlg::getAxisDimension() const
@@ -83,7 +83,7 @@ void ccUnrollDlg::shapeTypeChanged(int index)
 {
 	switch (index)
 	{
-	case CYLINDER: //cylinder
+	case ccPointCloud::CYLINDER: //cylinder
 	{
 		angleFrame->setVisible(false);
 		autoCenterFrame->setVisible(true);
@@ -91,10 +91,9 @@ void ccUnrollDlg::shapeTypeChanged(int index)
 		groupBoxAxisPosition->setTitle("Axis position");
 		radiusLabel->setText("Radius");
 		axisAutoStateChanged(checkBoxAuto->checkState());
-		unrollRangeGroupBox->setVisible(true);
 	}
 	break;
-	case CONE: //cone
+	case ccPointCloud::CONE: //cone
 	{
 		angleFrame->setVisible(true);
 		autoCenterFrame->setVisible(false);
@@ -102,17 +101,24 @@ void ccUnrollDlg::shapeTypeChanged(int index)
 		radiusLabel->setText("Base radius");
 		groupBoxAxisPosition->setTitle("Cone apex");
 		axisAutoStateChanged(Qt::Unchecked);
-		unrollRangeGroupBox->setVisible(false);
+		//may be disabled if we were in cylinder mode previously
+		doubleSpinBoxAxisX->setDisabled(false);
+		doubleSpinBoxAxisY->setDisabled(false);
+		doubleSpinBoxAxisZ->setDisabled(false);
 	}
 	break;
-	case STRAIGHTENED_CONE: //straightened cone
+	case ccPointCloud::STRAIGHTENED_CONE: //straightened cone (fixed radius)
+	case ccPointCloud::STRAIGHTENED_CONE2: //straightened cone 2
 	{
 		angleFrame->setVisible(true);
 		radiusFrame->setVisible(true);
 		autoCenterFrame->setVisible(false);
 		groupBoxAxisPosition->setTitle("Cone apex");
 		axisAutoStateChanged(Qt::Unchecked);
-		unrollRangeGroupBox->setVisible(false);
+		//may be disabled if we were in cylinder mode previously
+		doubleSpinBoxAxisX->setDisabled(false);
+		doubleSpinBoxAxisY->setDisabled(false);
+		doubleSpinBoxAxisZ->setDisabled(false);
 	}
 	break;
 	};

--- a/qCC/ccUnrollDlg.h
+++ b/qCC/ccUnrollDlg.h
@@ -22,6 +22,8 @@
 
 //CCLib
 #include <CCGeom.h>
+//qCC_db
+#include <ccPointCloud.h>
 
 //! Dialog: unroll clould on a cylinder or a cone
 class ccUnrollDlg : public QDialog, public Ui::UnrollDialog
@@ -33,10 +35,7 @@ public:
 	//! Default constructor
 	explicit ccUnrollDlg(QWidget* parent = 0);
 
-	//! Projection type
-	enum Type { CYLINDER, CONE, STRAIGHTENED_CONE };
-
-	Type getType() const;
+	ccPointCloud::UnrollMode getType() const;
 	int getAxisDimension() const;
 	bool isAxisPositionAuto() const;
 	CCVector3 getAxisPosition() const;

--- a/qCC/ui_templates/unrollDlg.ui
+++ b/qCC/ui_templates/unrollDlg.ui
@@ -37,6 +37,11 @@
        </item>
        <item>
         <property name="text">
+         <string>Straightened cone (fixed radius)</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
          <string>Straightened cone</string>
         </property>
        </item>


### PR DESCRIPTION
- ability to set the start and stop angles for the cone unrolling options
- new unrolling mode: 'Straightened cone' (the previous one has been renamed 'Straightened cone (fixed radius)'). This new mode unrolls the cone as a cylinder but with a varying radius.
- the 'Straightened cone' options are now using the real curvilinear abscissa (0 = cone apex)

Bug fix: the Unroll dialog was not enabling all the apex coordinate fields after switching from Cylinder to Cone mode